### PR TITLE
Graphs for multiple projects and cluster access control

### DIFF
--- a/webawesome/templates/en-us/PageLayout.htm
+++ b/webawesome/templates/en-us/PageLayout.htm
@@ -175,7 +175,7 @@
                 <wa-icon class="fa-regular fa-memory"></wa-icon>
                 GPU devices
               </wa-button>
-                <wa-button variant="brand" id="site-aside-left-model-button-Project" href="{{ SITE_BASE_URL }}/en-us/search/project?facet.field=hubId">
+                <wa-button variant="brand" id="site-aside-left-model-button-Project" href="{{ SITE_BASE_URL }}/en-us/search/project?facet.field=hubId&facet.field=clusterName">
                 <wa-icon class="fa-regular fa-school"></wa-icon>
                 projects
               </wa-button>

--- a/webawesome/templates/en-us/edit/cluster/ClusterEditPage.htm
+++ b/webawesome/templates/en-us/edit/cluster/ClusterEditPage.htm
@@ -7,6 +7,20 @@
     Observability dashboard for cluster {{ result.clusterName }}
   </div>
   <div class="wa-stack ">
+    <div class="wa-stack ">
+      <div>
+        <wa-button variant="brand" href="{{ SITE_BASE_URL }}/en-us/search/project?fq={{ 'hubId:' + result.hubId | urlencode() }}&fq={{ 'clusterName:' + result.clusterName | urlencode() }}&facet.field=hubId&facet.field=clusterName">
+          <i slot="start" class="fa-regular fa-school"></i>
+          View all projects in the {{ result.clusterName | e }} cluster in the {{ result.hubId }} hub
+        </wa-button>
+      </div>
+      <div>
+        <wa-button variant="brand" href="{{ SITE_BASE_URL }}/en-us/search/ai-node?fq={{ 'hubId:' + result.hubId | urlencode() }}&fq={{ 'clusterName:' + result.clusterName | urlencode() }}&facet.field=hubId&facet.field=clusterName">
+          <i slot="start" class="fa-regular fa-computer"></i>
+          View all nodes in the {{ result.clusterName | e }} cluster in the {{ result.hubId }} hub
+        </wa-button>
+      </div>
+    </div>
     <div class="wa-grid ">
       <wa-card with-header>
         <header slot="header" class="wa-heading-m ">Percent of total memory usage for {{ result.clusterName }} cluster</header>

--- a/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
+++ b/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
@@ -4,7 +4,7 @@
 {% if result is defined %}
 <wa-details open class="HtmRow" id="observability-dashboard">
   <div slot="summary">
-    Observability dashboard for cluster {{ result.clusterName }} project {{ result.projectName }}
+    Observability dashboard for OpenShift projects
   </div>
   <div class="wa-stack ">
     <div class="wa-grid ">

--- a/webawesome/templates/en-us/search/cluster/ClusterSearchPage.htm
+++ b/webawesome/templates/en-us/search/cluster/ClusterSearchPage.htm
@@ -3,7 +3,7 @@
 {% if resultCount > 0 %}
 <wa-details open class="HtmRow" id="observability-dashboard">
   <div slot="summary">
-    Observability dashboard for all OpenShift clusters
+    Observability dashboard for OpenShift clusters
   </div>
   <div class="wa-stack ">
     <div class="wa-grid ">
@@ -129,7 +129,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
-              query: 'cluster:memory_usage_bytes:sum / on(cluster) cluster:capacity_memory_bytes:sum{label_node_role_kubernetes_io!="master"}' 
+              query: 'cluster:memory_usage_bytes:sum{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %} / on(cluster) cluster:capacity_memory_bytes:sum{ {% if filteredScope %}cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}", {% endif %}label_node_role_kubernetes_io!="master" }' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -182,7 +182,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
-              query: 'cluster:cpu_usage_cores:sum{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName}}{% endfor %}"}{% endif %} / on(cluster) sum by (cluster) (cluster:capacity_cpu_cores:sum{label_node_role_kubernetes_io!="master"{% if filteredScope %},cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName}}{% endfor %}"{% endif %}})' 
+              query: 'cluster:cpu_usage_cores:sum{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %} / on(cluster) sum by (cluster) (cluster:capacity_cpu_cores:sum{label_node_role_kubernetes_io!="master"{% if filteredScope %},cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName}}{% endfor %}"{% endif %}})' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -235,7 +235,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
-            query: 'sum(DCGM_FI_DEV_GPU_UTIL) by (cluster)' 
+            query: 'sum(DCGM_FI_DEV_GPU_UTIL{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %} / 100) by (cluster)' 
           }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -288,7 +288,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query?' + new URLSearchParams(Object.assign({ 
-              query: 'sum(gpu_operator_gpu_nodes_total)' 
+              query: 'sum(gpu_operator_gpu_nodes_total{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %})' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -313,7 +313,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query?' + new URLSearchParams(Object.assign({ 
-              query: 'sum(gpu_operator_node_device_plugin_devices_total)' 
+              query: 'sum(gpu_operator_node_device_plugin_devices_total{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %})' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -338,7 +338,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query?' + new URLSearchParams(Object.assign({ 
-              query: 'sum(gpu_operator_node_device_plugin_devices_total) by (cluster)' 
+              query: 'sum(gpu_operator_node_device_plugin_devices_total{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %}) by (cluster)' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -388,7 +388,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query?' + new URLSearchParams(Object.assign({ 
-              query: 'sum(gpu_operator_node_device_plugin_devices_total) by (cluster, node)' 
+              query: 'sum(gpu_operator_node_device_plugin_devices_total{% if filteredScope %}{cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}"}{% endif %}) by (cluster, node)' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -443,7 +443,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query?' + new URLSearchParams(Object.assign({ 
-              query: 'kube_node_status_condition{status="unknown", condition="Ready"} * on (cluster, node) group_left(label_nvidia_com_gpu_present) (sum by (cluster, node, label_nvidia_com_gpu_present) (kube_node_labels{label_nvidia_com_gpu_present="true"})) > 0' 
+              query: 'kube_node_status_condition{ {% if filteredScope %}cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}", {% endif %}status="unknown", condition="Ready"} * on (cluster, node) group_left(label_nvidia_com_gpu_present) (sum by (cluster, node, label_nvidia_com_gpu_present) (kube_node_labels{ {% if filteredScope %}cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}", {% endif %}label_nvidia_com_gpu_present="true" })) > 0' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
@@ -498,7 +498,7 @@
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
         hubIds.forEach((hubId, i) => {
           urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query?' + new URLSearchParams(Object.assign({ 
-              query: '(sum by (cluster, node, label_nvidia_com_gpu_present) (kube_node_labels{label_nvidia_com_gpu_present="true"})) > 0 unless on(cluster, node) kube_node_spec_taint{key="nvidia.com/gpu.product"}' 
+              query: '(sum by (cluster, node, label_nvidia_com_gpu_present) (kube_node_labels{ {% if filteredScope %}cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}", {% endif %}label_nvidia_com_gpu_present="true" })) > 0 unless on(cluster, node) kube_node_spec_taint{ {% if filteredScope %}cluster=~"{% for cluster in listCluster%}{% if loop.index0 > 0 %}|{% endif %}{{cluster.clusterName | e }}{% endfor %}", {% endif %}key="nvidia.com/gpu.product" }' 
               }, timeQuery)).toString());
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));

--- a/webawesome/templates/en-us/search/project/ProjectSearchPage.htm
+++ b/webawesome/templates/en-us/search/project/ProjectSearchPage.htm
@@ -1,1 +1,444 @@
 {% extends "en-us/search/project/ProjectGenSearchPage.htm" %}
+{%- block htmBodyEndProjectPage %}
+{% if resultCount > 0 %}
+<wa-details open class="HtmRow" id="observability-dashboard">
+  <div slot="summary">
+    Observability dashboard for OpenShift projects
+  </div>
+  <div class="wa-stack ">
+    <div class="wa-grid ">
+      <wa-card with-header>
+        <header slot="header" class="wa-heading-m ">Total project memory usage</header>
+        <div id="visualization-total-memory-bytes" class=""></div>
+      </wa-card>
+      <wa-card with-header>
+        <header slot="header" class="wa-heading-m ">Total project CPU usage</header>
+        <div id="visualization-total-cpu-bytes" class=""></div>
+      </wa-card>
+    </div>
+    <div class="wa-grid ">
+      <wa-card with-header>
+        <header slot="header" class="wa-heading-m ">Project quota memory usage</header>
+        <div id="visualization-quota-memory-bytes" class=""></div>
+      </wa-card>
+      <wa-card with-header>
+        <header slot="header" class="wa-heading-m ">Project quota CPU usage</header>
+        <div id="visualization-quota-cpu-bytes" class=""></div>
+      </wa-card>
+    </div>
+    <wa-card with-header>
+      <header slot="header" class="wa-heading-l ">Project GPU utilization</header>
+      <div id="visualization-cluster-gpu-utilization" class="wa-grid "></div>
+    </wa-card>
+  </div>
+</wa-details>
+{% endif %}
+{{ super() }}
+{%- endblock htmBodyEndProjectPage %}
+{%- block htmStyleProjectPage %}
+#visualization-cluster-gpu-nodes, #visualization-cluster-gpu-devices {
+  wa-avatar {
+    --size: 3em;
+  }
+}
+#observability-dashboard {
+  .pill {
+    border-radius: var(--wa-border-radius-pill);
+    box-shadow: var(--wa-theme-glossy-inner-shine), var(--wa-theme-glossy-top-highlight), inset 0 .7rem 0 0 rgba(255, 255, 255, 0.1), var(--wa-theme-glossy-lower-shade), var(--wa-theme-glossy-bottom-shadow);
+    &:hover {
+     background-color: var(--background-color-hover, var(--background-color));
+      border-color: var(--border-color-hover, var(--border-color, var(--background-color-hover)));
+      color: var(--text-color-hover, var(--text-color));
+    }
+  }
+}
+{%- endblock htmStyleProjectPage %}
+{%- block htmScriptInitProjectPage %}
+
+      var facetRangeGapVal = document.querySelector("#pageSearchVal-pageFacetRangeGap-Project-input").value;
+      var start = '{{ formatZonedDateTime(defaultRangeStart, "yyyy-MM-dd'T'HH:mm:ss.SSSX", defaultLocaleId, 'UTC') }}';
+      var end = '{{ formatZonedDateTime(defaultRangeEnd, "yyyy-MM-dd'T'HH:mm:ss.SSSX", defaultLocaleId, 'UTC') }}';
+      var step;
+      switch (facetRangeGapVal) {
+        case "+1YEAR":
+          step = "1y";
+          break;
+        case "+1MONTH":
+          step = "1M";
+          break;
+        case "+1DAY":
+          step = "1d";
+          break;
+        case "+1HOUR":
+          step = "1h";
+          break;
+        case "+1MINUTE":
+          step = "1m";
+          break;
+        default:
+          dayType = "Weekend";
+      }
+
+      var timeQuery = {
+        start: start
+        , end: end
+        , step: step
+      };
+
+      Promise.all([
+          queryTotalMemoryBytes(timeQuery)
+          , queryTotalCpuBytes(timeQuery)
+          , queryQuotaMemoryBytes(timeQuery)
+          , queryQuotaCpuBytes(timeQuery)
+          , queryGpuUtilization(timeQuery)
+          ]);
+{%- endblock htmScriptInitProjectPage %}
+{%- block htmScriptsProjectPage %}
+{{ super() }}
+  <script>
+
+    async function queryTotalMemoryBytes(timeQuery) {
+      const urls = [];
+      const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
+      var requestHubIds = [];
+      hubIds.forEach((hubId, i) => {
+        var projects = listProject.filter(project => project.hubId === hubId);
+        var uniqueClusterNames = [...new Set(projects.map(item => item.clusterName))];
+        uniqueClusterNames.forEach((clusterName, i) => {
+          var uniqueProjectNames = projects.filter(project => project.clusterName === clusterName).map(project => project.projectName);
+          var projectNamesFilter = '{ cluster="' + clusterName + '", namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
+              query: 'namespace:container_memory_usage_bytes:sum' + projectNamesFilter
+              }, timeQuery)).toString());
+          requestHubIds.push(hubId);
+        });
+      });
+      const responses = await Promise.all(urls.map(url => fetch(url)));
+      const dataPromises = responses.map(response => response.json());
+      const responseJsons = await Promise.all(dataPromises);
+      var end = new Date();
+      var start = new Date(new Date().setHours(end.getHours() - 1));
+
+      var panelId = 'visualization-total-memory-bytes';
+      var traces = [];
+      responseJsons.forEach((responseJson, i) => {
+        var hubId = requestHubIds[i];
+        responseJson.data.result.forEach((result, j) => {
+          traces.push({
+            x: result.values.map(values => new Date(values[0] * 1000))
+            , y: result.values.map(values => parseFloat(values[1]))
+            , mode: 'scatter'
+            , name: (result.metric.namespace + ' in ' + result.metric.cluster + ' in ' + hubId).substring(0, 90)
+            , text: result.values.map(values => '<a href="/en-us/edit/cluster/' + result.metric.cluster + '">' + hubId + ' ' + result.metric.cluster + ' ' + result.metric.namespace + '</a>')
+          });
+        });
+      });
+
+      var layout = {
+        xaxis: {
+          title: 'Time in {{ defaultZoneId }}'
+        }
+        , yaxis: {
+          title: 'Total memory usage'
+        }
+        , legend: {
+          title: {
+            text: 'Projects'
+          }
+          , xanchor: 'center'
+          , x: 0.4
+          , yanchor: 'top'
+          , y: -0.2
+          , orientation: 'v'
+        }
+        , height: 600
+        , margin: {
+          l: 50
+          , r: 0
+          , b: 0
+          , t: 0
+          , pad: 1
+        }
+      };
+      Plotly.newPlot(panelId, traces, layout);
+    }
+
+    async function queryTotalCpuBytes(timeQuery) {
+      const urls = [];
+      const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
+      var requestHubIds = [];
+      hubIds.forEach((hubId, i) => {
+        var projects = listProject.filter(project => project.hubId === hubId);
+        var uniqueClusterNames = [...new Set(projects.map(item => item.clusterName))];
+        uniqueClusterNames.forEach((clusterName, i) => {
+          var uniqueProjectNames = projects.filter(project => project.clusterName === clusterName).map(project => project.projectName);
+          var projectNamesFilter = '{ cluster="' + clusterName + '", namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
+              query: 'node_namespace_pod_container:container_cpu_usage_seconds_total:sum' + projectNamesFilter
+              }, timeQuery)).toString());
+          requestHubIds.push(hubId);
+        });
+      });
+      const responses = await Promise.all(urls.map(url => fetch(url)));
+      const dataPromises = responses.map(response => response.json());
+      const responseJsons = await Promise.all(dataPromises);
+      var end = new Date();
+      var start = new Date(new Date().setHours(end.getHours() - 1));
+
+      var panelId = 'visualization-total-cpu-bytes';
+      var traces = [];
+      responseJsons.forEach((responseJson, i) => {
+        var hubId = requestHubIds[i];
+        responseJson.data.result.forEach((result, j) => {
+          traces.push({
+            x: result.values.map(values => new Date(values[0] * 1000))
+            , y: result.values.map(values => parseFloat(values[1]))
+            , mode: 'scatter'
+            , name: (result.metric.namespace + ' in ' + result.metric.cluster + ' in ' + hubId).substring(0, 90)
+            , text: result.values.map(values => '<a href="/en-us/edit/cluster/' + result.metric.cluster + '">' + hubId + ' ' + result.metric.cluster + ' ' + result.metric.namespace + '</a>')
+          });
+        });
+      });
+
+      var layout = {
+        xaxis: {
+          title: 'Time in {{ defaultZoneId }}'
+        }
+        , yaxis: {
+          title: 'Total CPU usage'
+        }
+        , legend: {
+          title: {
+            text: 'Projects'
+          }
+          , xanchor: 'center'
+          , x: 0.4
+          , yanchor: 'top'
+          , y: -0.2
+          , orientation: 'v'
+        }
+        , height: 600
+        , margin: {
+          l: 50
+          , r: 0
+          , b: 0
+          , t: 0
+          , pad: 1
+        }
+      };
+      Plotly.newPlot(panelId, traces, layout);
+    }
+
+    async function queryQuotaMemoryBytes(timeQuery) {
+      const urls = [];
+      const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
+      var requestHubIds = [];
+      hubIds.forEach((hubId, i) => {
+        var projects = listProject.filter(project => project.hubId === hubId);
+        var uniqueClusterNames = [...new Set(projects.map(item => item.clusterName))];
+        uniqueClusterNames.forEach((clusterName, i) => {
+          var uniqueProjectNames = projects.filter(project => project.clusterName === clusterName).map(project => project.projectName);
+          var projectNamesFilter = '{ cluster="' + clusterName + '", namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          var projectNamesQuotaFilter = '{ resource="limits.memory", type="hard", cluster="' + clusterName + '", namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
+              query: 'namespace:container_memory_usage_bytes:sum' + projectNamesFilter + ' / on(cluster, namespace) kube_resourcequota' + projectNamesQuotaFilter
+              }, timeQuery)).toString());
+          requestHubIds.push(hubId);
+        });
+      });
+      const responses = await Promise.all(urls.map(url => fetch(url)));
+      const dataPromises = responses.map(response => response.json());
+      const responseJsons = await Promise.all(dataPromises);
+      var end = new Date();
+      var start = new Date(new Date().setHours(end.getHours() - 1));
+
+      var panelId = 'visualization-quota-memory-bytes';
+      var traces = [];
+      responseJsons.forEach((responseJson, i) => {
+        var hubId = requestHubIds[i];
+        responseJson.data.result.forEach((result, j) => {
+          traces.push({
+            x: result.values.map(values => new Date(values[0] * 1000))
+            , y: result.values.map(values => parseFloat(values[1]))
+            , mode: 'scatter'
+            , name: (result.metric.namespace + ' in ' + result.metric.cluster + ' in ' + hubId).substring(0, 90)
+            , text: result.values.map(values => '<a href="/en-us/edit/cluster/' + result.metric.cluster + '">' + hubId + ' ' + result.metric.cluster + ' ' + result.metric.namespace + '</a>')
+          });
+        });
+      });
+
+      var layout = {
+        xaxis: {
+          title: 'Time in {{ defaultZoneId }}'
+        }
+        , yaxis: {
+          title: 'Percent of total memory usage'
+          , tickformat: '.0%'
+        }
+        , legend: {
+          title: {
+            text: 'Projects'
+          }
+          , xanchor: 'center'
+          , x: 0.4
+          , yanchor: 'top'
+          , y: -0.2
+          , orientation: 'v'
+        }
+        , height: 600
+        , margin: {
+          l: 50
+          , r: 0
+          , b: 0
+          , t: 0
+          , pad: 1
+        }
+      };
+      if(traces.length > 0)
+        Plotly.newPlot(panelId, traces, layout);
+      else
+        document.querySelector('#' + panelId).parentElement.remove();
+    }
+
+    async function queryQuotaCpuBytes(timeQuery) {
+      const urls = [];
+      const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
+      var requestHubIds = [];
+      hubIds.forEach((hubId, i) => {
+        var projects = listProject.filter(project => project.hubId === hubId);
+        var uniqueClusterNames = [...new Set(projects.map(item => item.clusterName))];
+        uniqueClusterNames.forEach((clusterName, i) => {
+          var uniqueProjectNames = projects.filter(project => project.clusterName === clusterName).map(project => project.projectName);
+          var projectNamesFilter = '{ cluster="' + clusterName + '", namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          var projectNamesQuotaFilter = '{ resource="limits.cpu", type="hard", cluster="' + clusterName + '", namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
+              query: 'node_namespace_pod_container:container_cpu_usage_seconds_total:sum' + projectNamesFilter + ' / on(cluster, namespace) kube_resourcequota' + projectNamesQuotaFilter
+              }, timeQuery)).toString());
+          requestHubIds.push(hubId);
+        });
+      });
+      const responses = await Promise.all(urls.map(url => fetch(url)));
+      const dataPromises = responses.map(response => response.json());
+      const responseJsons = await Promise.all(dataPromises);
+      var end = new Date();
+      var start = new Date(new Date().setHours(end.getHours() - 1));
+
+      var panelId = 'visualization-quota-cpu-bytes';
+      var traces = [];
+      responseJsons.forEach((responseJson, i) => {
+        var hubId = requestHubIds[i];
+        responseJson.data.result.forEach((result, j) => {
+          traces.push({
+            x: result.values.map(values => new Date(values[0] * 1000))
+            , y: result.values.map(values => parseFloat(values[1]))
+            , mode: 'scatter'
+            , name: (result.metric.namespace + ' in ' + result.metric.cluster + ' in ' + hubId).substring(0, 90)
+            , text: result.values.map(values => '<a href="/en-us/edit/cluster/' + result.metric.cluster + '">' + hubId + ' ' + result.metric.cluster + ' ' + result.metric.namespace + '</a>')
+          });
+        });
+      });
+
+      var layout = {
+        xaxis: {
+          title: 'Time in {{ defaultZoneId }}'
+        }
+        , yaxis: {
+          title: 'Percent of total CPU usage'
+          , tickformat: '.0%'
+        }
+        , legend: {
+          title: {
+            text: 'Projects'
+          }
+          , xanchor: 'center'
+          , x: 0.4
+          , yanchor: 'top'
+          , y: -0.2
+          , orientation: 'v'
+        }
+        , height: 600
+        , margin: {
+          l: 50
+          , r: 0
+          , b: 0
+          , t: 0
+          , pad: 1
+        }
+      };
+      if(traces.length > 0)
+        Plotly.newPlot(panelId, traces, layout);
+      else
+        document.querySelector('#' + panelId).parentElement.remove();
+    }
+
+    async function queryGpuUtilization(timeQuery) {
+      const urls = [];
+      const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
+      var requestHubIds = [];
+      hubIds.forEach((hubId, i) => {
+        var projects = listProject.filter(project => project.hubId === hubId);
+        var uniqueClusterNames = [...new Set(projects.map(item => item.clusterName))];
+        uniqueClusterNames.forEach((clusterName, i) => {
+          var uniqueProjectNames = projects.filter(project => project.clusterName === clusterName).map(project => project.projectName);
+          var projectNamesFilter = '{ cluster="' + clusterName + '", exported_namespace=~"' + uniqueProjectNames.join('|') + '" }';
+          urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
+              query: 'sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_UTIL' + projectNamesFilter + ' / 100)'
+              }, timeQuery)).toString());
+          requestHubIds.push(hubId);
+        });
+      });
+      const responses = await Promise.all(urls.map(url => fetch(url)));
+      const dataPromises = responses.map(response => response.json());
+      const responseJsons = await Promise.all(dataPromises);
+      var end = new Date();
+      var start = new Date(new Date().setHours(end.getHours() - 1));
+
+      var panelId = 'visualization-cluster-gpu-utilization';
+      var traces = [];
+      responseJsons.forEach((responseJson, i) => {
+        if(responseJson.data) {
+          var hubId = requestHubIds[i];
+          responseJson.data.result.forEach((result, j) => {
+            traces.push({
+              x: result.values.map(values => new Date(values[0] * 1000))
+              , y: result.values.map(values => parseFloat(values[1]))
+              , mode: 'lines+markers'
+              , name: (result.metric.exported_namespace + ' in ' + result.metric.cluster + ' in ' + hubId).substring(0, 90)
+              , text: result.values.map(values => '<a href="/en-us/edit/cluster/' + result.metric.cluster + '">' + hubId + ' ' + result.metric.cluster + ' ' + result.metric.exported_namespace + '</a>')
+            });
+          });
+        }
+      });
+
+      var layout = {
+        xaxis: {
+          title: 'Time in {{ defaultZoneId }}'
+        }
+        , yaxis: {
+          title: 'Percent of total GPU usage'
+          , tickformat: '.0%'
+        }
+        , legend: {
+          title: {
+            text: 'Projects'
+          }
+          , xanchor: 'center'
+          , x: 0.4
+          , yanchor: 'top'
+          , y: -0.2
+          , orientation: 'v'
+        }
+        , height: 600
+        , margin: {
+          l: 50
+          , r: 0
+          , b: 0
+          , t: 0
+          , pad: 1
+        }
+      };
+      Plotly.newPlot(panelId, traces, layout);
+    }
+  </script>
+{%- endblock htmScriptsProjectPage %}
+


### PR DESCRIPTION
Graphs are now visible for multiple projects and clusters at the same time with a filtered scope. For example, if I add permissions to my user in Keycloak for GET scope to 2 cluster and 2 projects: 
<img width="580" height="493" alt="image" src="https://github.com/user-attachments/assets/4974689a-089a-4de1-82b4-538cade0a27a" />

Here is what the projects dashboard looks like 4 2 clusters, and 2 projects. Notice there are several projects visible from the nerc-ocp-test cluster, more than the 2 I was assigned to directly. 
<img width="1592" height="3561" alt="image" src="https://github.com/user-attachments/assets/04258810-630e-4d98-a3f2-2d6368d5483d" />
